### PR TITLE
Improve contrast of text in the announcement banner

### DIFF
--- a/docs/source/_static/jupyter.css
+++ b/docs/source/_static/jupyter.css
@@ -13,10 +13,12 @@ html[data-theme="light"], html[data-theme="dark"] {
 
 .bd-header-announcement {
   color: var(--pst-color-white);
+  text-shadow: 0 0 5px rgba(0, 0, 0, 33%);
 }
 
 .bd-header-announcement a {
   color: var(--bs-primary-text-emphasis) !important;
+  text-shadow: none;
 }
 .bd-header-announcement a:hover {
   color: var(--bs-blue) !important;

--- a/docs/source/_static/jupyter.css
+++ b/docs/source/_static/jupyter.css
@@ -11,9 +11,13 @@ html[data-theme="light"], html[data-theme="dark"] {
     --pst-color-table-row-hover-bg: var(--pst-gray-200);
 }
 
+.bd-header-announcement {
+  color: var(--pst-color-white);
+}
+
 .bd-header-announcement a {
-  color: var(--bs-blue) !important;
+  color: var(--bs-primary-text-emphasis) !important;
 }
 .bd-header-announcement a:hover {
-  color: var(--bs-cyan) !important;
+  color: var(--bs-blue) !important;
 }


### PR DESCRIPTION
| Before | After * |
|--|--|
| <img width="1196" height="408" alt="image" src="https://github.com/user-attachments/assets/8d5f7d69-f51b-4bbb-b054-306c013818b5" /> | <img width="1196" height="408" alt="image" src="https://github.com/user-attachments/assets/d1f9e45c-35db-4ecb-bb5c-3519208cc19a" /> |

* Addition of `text-shadow` compensates for the low contrast, this is not captured by this tool for AA purposes

| Before | After |
|--|--|
| <img width="1196" height="408" alt="image" src="https://github.com/user-attachments/assets/7b5df18a-382c-4cbb-9290-b29c4ff6b605" /> | <img width="1196" height="408" alt="image" src="https://github.com/user-attachments/assets/95701d52-0d1d-4ea7-9b89-2f1225bc4094" /> |

I still don't like the blue (now it's too dark) but among variables available this is the best option I see. Happy for someone else to suggest something better.